### PR TITLE
example code minor error fix:

### DIFF
--- a/examples/multiclass_classification.ipynb
+++ b/examples/multiclass_classification.ipynb
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 19,
    "id": "d1bed877-36cb-426d-a86b-143eb8d5319a",
    "metadata": {},
    "outputs": [],
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 20,
    "id": "bee00548-e660-4b0d-b621-9d76b745c3c7",
    "metadata": {},
    "outputs": [],
@@ -88,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 21,
    "id": "418753ec-f6b8-48dd-94e2-2c8a2956aa8b",
    "metadata": {},
    "outputs": [
@@ -287,7 +287,7 @@
        "[5 rows x 37 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -298,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 22,
    "id": "eaa224f9-2ff0-441e-bcf4-4bdbe4589584",
    "metadata": {},
    "outputs": [
@@ -315,7 +315,7 @@
        "Name: count, dtype: int64"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 23,
    "id": "c1f6e283-c945-43d6-b94d-4f55e52c0579",
    "metadata": {},
    "outputs": [],
@@ -353,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 24,
    "id": "e3d921f2-e4cb-40d7-8b81-d93cbca874fd",
    "metadata": {},
    "outputs": [],
@@ -373,7 +373,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 25,
    "id": "6e1450f2-373f-4464-8143-0da7642e8ccb",
    "metadata": {},
    "outputs": [],
@@ -384,7 +384,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 26,
    "id": "75502f56-6925-491d-9f34-fb5ac650837c",
    "metadata": {},
    "outputs": [],
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 27,
    "id": "2eda5de9-9f96-4734-bf5a-e8e9e5cacb5c",
    "metadata": {},
    "outputs": [],
@@ -482,7 +482,7 @@
     "    va = VennAbersCalibrator(clf, inductive=True, cal_size=0.2, random_state=42)\n",
     "    va.fit(np.asarray(X_train), np.asarray(y_train))\n",
     "    p_pred_va = va.predict_proba(np.array(X_test))\n",
-    "    y_pred = va.predict(X_test, one_hot=False)\n",
+    "    y_pred = va.predict(np.array(X_test), one_hot=False)\n",
     "    acc_list.append(accuracy_score(y_test, y_pred))\n",
     "    log_loss_list.append(log_loss(y_test, p_pred_va))\n",
     "    brier_loss_list.append(brier_loss_calc(y_test_binary, p_pred_va))\n",
@@ -491,7 +491,7 @@
     "    va_cv = VennAbersCalibrator(clf, inductive=False, n_splits=5)\n",
     "    va_cv.fit(np.asarray(X_train), np.asarray(y_train))\n",
     "    p_pred_cv = va_cv.predict_proba(np.asarray(X_test))\n",
-    "    y_pred = va_cv.predict(X_test, one_hot=False)\n",
+    "    y_pred = va_cv.predict(np.array(X_test), one_hot=False)\n",
     "    acc_list.append(accuracy_score(y_test, y_pred))\n",
     "    log_loss_list.append(log_loss(y_test, p_pred_cv))\n",
     "    brier_loss_list.append(brier_loss_calc(y_test_binary, p_pred_cv))\n",
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 28,
    "id": "99cb6f80-e9cc-46ae-ba09-44250c6eef6b",
    "metadata": {},
    "outputs": [
@@ -606,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 29,
    "id": "dac8e836-ca42-4ed4-a336-acf35bfba294",
    "metadata": {},
    "outputs": [
@@ -659,7 +659,7 @@
        "      <td>0.795</td>\n",
        "      <td>0.806</td>\n",
        "      <td>0.814</td>\n",
-       "      <td>0.816</td>\n",
+       "      <td>0.814</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SVM</th>\n",
@@ -669,17 +669,17 @@
        "      <td>0.892</td>\n",
        "      <td>0.890</td>\n",
        "      <td>0.899</td>\n",
-       "      <td>0.894</td>\n",
+       "      <td>0.892</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>RF</th>\n",
-       "      <td>0.906</td>\n",
-       "      <td>0.896</td>\n",
-       "      <td>0.894</td>\n",
+       "      <td>0.902</td>\n",
+       "      <td>0.890</td>\n",
+       "      <td>0.890</td>\n",
        "      <td>0.905</td>\n",
        "      <td>0.902</td>\n",
-       "      <td>0.896</td>\n",
-       "      <td>0.904</td>\n",
+       "      <td>0.897</td>\n",
+       "      <td>0.900</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>XGB</th>\n",
@@ -689,7 +689,7 @@
        "      <td>0.740</td>\n",
        "      <td>0.770</td>\n",
        "      <td>0.885</td>\n",
-       "      <td>0.888</td>\n",
+       "      <td>0.884</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Logistic</th>\n",
@@ -703,13 +703,13 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Neural Network</th>\n",
+       "      <td>0.902</td>\n",
+       "      <td>0.886</td>\n",
+       "      <td>0.888</td>\n",
+       "      <td>0.903</td>\n",
+       "      <td>0.902</td>\n",
        "      <td>0.900</td>\n",
-       "      <td>0.894</td>\n",
-       "      <td>0.892</td>\n",
-       "      <td>0.904</td>\n",
-       "      <td>0.907</td>\n",
-       "      <td>0.899</td>\n",
-       "      <td>0.897</td>\n",
+       "      <td>0.902</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -720,22 +720,22 @@
        "Classifier                                                                    \n",
        "Naive Bayes            0.796  0.792     0.804     0.795        0.806  0.814   \n",
        "SVM                    0.894  0.880     0.880     0.892        0.890  0.899   \n",
-       "RF                     0.906  0.896     0.894     0.905        0.902  0.896   \n",
+       "RF                     0.902  0.890     0.890     0.905        0.902  0.897   \n",
        "XGB                    0.750  0.518     0.576     0.740        0.770  0.885   \n",
        "Logistic               0.862  0.802     0.822     0.790        0.814  0.872   \n",
-       "Neural Network         0.900  0.894     0.892     0.904        0.907  0.899   \n",
+       "Neural Network         0.902  0.886     0.888     0.903        0.902  0.900   \n",
        "\n",
        "                 CVAP  \n",
        "Classifier             \n",
-       "Naive Bayes     0.816  \n",
-       "SVM             0.894  \n",
-       "RF              0.904  \n",
-       "XGB             0.888  \n",
+       "Naive Bayes     0.814  \n",
+       "SVM             0.892  \n",
+       "RF              0.900  \n",
+       "XGB             0.884  \n",
        "Logistic        0.870  \n",
-       "Neural Network  0.897  "
+       "Neural Network  0.902  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -755,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 30,
    "id": "0f905f30-8423-4f42-bc7f-20c998a7794e",
    "metadata": {},
    "outputs": [
@@ -808,7 +808,7 @@
        "      <td>0.0556</td>\n",
        "      <td>0.0469</td>\n",
        "      <td>0.0439</td>\n",
-       "      <td>0.0440</td>\n",
+       "      <td>0.0444</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SVM</th>\n",
@@ -818,17 +818,17 @@
        "      <td>0.0304</td>\n",
        "      <td>0.0274</td>\n",
        "      <td>0.0249</td>\n",
-       "      <td>0.0268</td>\n",
+       "      <td>0.0270</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>RF</th>\n",
-       "      <td>0.0237</td>\n",
-       "      <td>0.0249</td>\n",
-       "      <td>0.0245</td>\n",
+       "      <td>0.0241</td>\n",
+       "      <td>0.0254</td>\n",
+       "      <td>0.0253</td>\n",
        "      <td>0.0233</td>\n",
-       "      <td>0.0227</td>\n",
-       "      <td>0.0252</td>\n",
-       "      <td>0.0247</td>\n",
+       "      <td>0.0228</td>\n",
+       "      <td>0.0246</td>\n",
+       "      <td>0.0248</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>XGB</th>\n",
@@ -838,7 +838,7 @@
        "      <td>0.0744</td>\n",
        "      <td>0.0613</td>\n",
        "      <td>0.0282</td>\n",
-       "      <td>0.0279</td>\n",
+       "      <td>0.0280</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Logistic</th>\n",
@@ -848,16 +848,16 @@
        "      <td>0.0515</td>\n",
        "      <td>0.0455</td>\n",
        "      <td>0.0298</td>\n",
-       "      <td>0.0313</td>\n",
+       "      <td>0.0312</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Neural Network</th>\n",
-       "      <td>0.0273</td>\n",
-       "      <td>0.0304</td>\n",
-       "      <td>0.0263</td>\n",
-       "      <td>0.0241</td>\n",
-       "      <td>0.0225</td>\n",
+       "      <td>0.0270</td>\n",
+       "      <td>0.0324</td>\n",
        "      <td>0.0269</td>\n",
+       "      <td>0.0243</td>\n",
+       "      <td>0.0222</td>\n",
+       "      <td>0.0264</td>\n",
        "      <td>0.0247</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -869,22 +869,22 @@
        "Classifier                                                                      \n",
        "Naive Bayes           0.0657  0.0571    0.0480    0.0556       0.0469  0.0439   \n",
        "SVM                   0.0257  0.0350    0.0309    0.0304       0.0274  0.0249   \n",
-       "RF                    0.0237  0.0249    0.0245    0.0233       0.0227  0.0252   \n",
+       "RF                    0.0241  0.0254    0.0253    0.0233       0.0228  0.0246   \n",
        "XGB                   0.0994  0.1025    0.0958    0.0744       0.0613  0.0282   \n",
        "Logistic              0.0323  0.0529    0.0481    0.0515       0.0455  0.0298   \n",
-       "Neural Network        0.0273  0.0304    0.0263    0.0241       0.0225  0.0269   \n",
+       "Neural Network        0.0270  0.0324    0.0269    0.0243       0.0222  0.0264   \n",
        "\n",
        "                  CVAP  \n",
        "Classifier              \n",
-       "Naive Bayes     0.0440  \n",
-       "SVM             0.0268  \n",
-       "RF              0.0247  \n",
-       "XGB             0.0279  \n",
-       "Logistic        0.0313  \n",
+       "Naive Bayes     0.0444  \n",
+       "SVM             0.0270  \n",
+       "RF              0.0248  \n",
+       "XGB             0.0280  \n",
+       "Logistic        0.0312  \n",
        "Neural Network  0.0247  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -896,7 +896,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 31,
    "id": "8b4b134a-841d-43b6-b399-51cb0f2c8d45",
    "metadata": {},
    "outputs": [
@@ -949,27 +949,27 @@
        "      <td>0.7532</td>\n",
        "      <td>0.5960</td>\n",
        "      <td>0.4894</td>\n",
-       "      <td>0.5085</td>\n",
+       "      <td>0.5135</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>SVM</th>\n",
-       "      <td>0.2805</td>\n",
+       "      <td>0.2806</td>\n",
        "      <td>0.4341</td>\n",
        "      <td>0.4587</td>\n",
        "      <td>0.3678</td>\n",
        "      <td>0.3335</td>\n",
        "      <td>0.2815</td>\n",
-       "      <td>0.3327</td>\n",
+       "      <td>0.3329</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>RF</th>\n",
-       "      <td>0.2652</td>\n",
-       "      <td>0.2937</td>\n",
-       "      <td>0.3328</td>\n",
-       "      <td>0.2729</td>\n",
-       "      <td>0.2849</td>\n",
-       "      <td>0.2857</td>\n",
-       "      <td>0.2958</td>\n",
+       "      <td>0.2692</td>\n",
+       "      <td>0.3005</td>\n",
+       "      <td>0.3837</td>\n",
+       "      <td>0.2721</td>\n",
+       "      <td>0.2722</td>\n",
+       "      <td>0.2854</td>\n",
+       "      <td>0.2957</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>XGB</th>\n",
@@ -979,7 +979,7 @@
        "      <td>0.9034</td>\n",
        "      <td>0.7280</td>\n",
        "      <td>0.3278</td>\n",
-       "      <td>0.3404</td>\n",
+       "      <td>0.3403</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Logistic</th>\n",
@@ -989,17 +989,17 @@
        "      <td>0.5951</td>\n",
        "      <td>0.5857</td>\n",
        "      <td>0.3310</td>\n",
-       "      <td>0.3702</td>\n",
+       "      <td>0.3703</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>Neural Network</th>\n",
-       "      <td>0.4900</td>\n",
-       "      <td>0.4154</td>\n",
-       "      <td>0.4622</td>\n",
-       "      <td>0.3210</td>\n",
-       "      <td>0.2437</td>\n",
-       "      <td>0.3520</td>\n",
-       "      <td>0.3032</td>\n",
+       "      <td>0.4727</td>\n",
+       "      <td>0.4427</td>\n",
+       "      <td>0.4013</td>\n",
+       "      <td>0.3213</td>\n",
+       "      <td>0.2407</td>\n",
+       "      <td>0.3314</td>\n",
+       "      <td>0.3030</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1009,23 +1009,23 @@
        "                Uncalibrated   Platt  Isotonic  Platt-CV  Isotonic-CV    IVAP  \\\n",
        "Classifier                                                                      \n",
        "Naive Bayes           4.0378  0.7704    0.6101    0.7532       0.5960  0.4894   \n",
-       "SVM                   0.2805  0.4341    0.4587    0.3678       0.3335  0.2815   \n",
-       "RF                    0.2652  0.2937    0.3328    0.2729       0.2849  0.2857   \n",
+       "SVM                   0.2806  0.4341    0.4587    0.3678       0.3335  0.2815   \n",
+       "RF                    0.2692  0.3005    0.3837    0.2721       0.2722  0.2854   \n",
        "XGB                   1.1760  1.2685    1.2437    0.9034       0.7280  0.3278   \n",
        "Logistic              0.3564  0.6104    0.6166    0.5951       0.5857  0.3310   \n",
-       "Neural Network        0.4900  0.4154    0.4622    0.3210       0.2437  0.3520   \n",
+       "Neural Network        0.4727  0.4427    0.4013    0.3213       0.2407  0.3314   \n",
        "\n",
        "                  CVAP  \n",
        "Classifier              \n",
-       "Naive Bayes     0.5085  \n",
-       "SVM             0.3327  \n",
-       "RF              0.2958  \n",
-       "XGB             0.3404  \n",
-       "Logistic        0.3702  \n",
-       "Neural Network  0.3032  "
+       "Naive Bayes     0.5135  \n",
+       "SVM             0.3329  \n",
+       "RF              0.2957  \n",
+       "XGB             0.3403  \n",
+       "Logistic        0.3703  \n",
+       "Neural Network  0.3030  "
       ]
      },
-     "execution_count": 13,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1045,24 +1045,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 32,
    "id": "5f906a20-3097-4ba2-9b4a-e281110b38fe",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Uncalibrated    0.851000\n",
-       "Platt           0.796833\n",
-       "Isotonic        0.811083\n",
-       "Platt-CV        0.837500\n",
-       "Isotonic-CV     0.848083\n",
-       "IVAP            0.877333\n",
-       "CVAP            0.878250\n",
+       "Uncalibrated    0.850833\n",
+       "Platt           0.794500\n",
+       "Isotonic        0.809917\n",
+       "Platt-CV        0.837333\n",
+       "Isotonic-CV     0.847167\n",
+       "IVAP            0.877750\n",
+       "CVAP            0.877083\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1081,7 +1081,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 33,
    "id": "3e4af628-c204-493f-90a0-5e0534577db0",
    "metadata": {},
    "outputs": [
@@ -1089,16 +1089,16 @@
      "data": {
       "text/plain": [
        "Uncalibrated    4.500000\n",
-       "Platt           6.666667\n",
-       "Isotonic        4.666667\n",
+       "Platt           6.833333\n",
+       "Isotonic        5.166667\n",
        "Platt-CV        4.000000\n",
        "Isotonic-CV     2.666667\n",
-       "IVAP            2.833333\n",
+       "IVAP            2.166667\n",
        "CVAP            2.666667\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1109,7 +1109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 34,
    "id": "808a22db-b7b4-454a-87c4-96e38886ce5d",
    "metadata": {},
    "outputs": [
@@ -1117,16 +1117,16 @@
      "data": {
       "text/plain": [
        "Uncalibrated    3.833333\n",
-       "Platt           5.833333\n",
-       "Isotonic        6.166667\n",
+       "Platt           6.166667\n",
+       "Isotonic        6.000000\n",
        "Platt-CV        4.000000\n",
        "Isotonic-CV     3.000000\n",
        "IVAP            2.166667\n",
-       "CVAP            3.000000\n",
+       "CVAP            2.833333\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,24 +1145,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 35,
    "id": "f306814c-a6d8-4b60-beca-ad995df4f8b0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Uncalibrated    0.045684\n",
-       "Platt           0.050454\n",
-       "Isotonic        0.045602\n",
-       "Platt-CV        0.043238\n",
-       "Isotonic-CV     0.037697\n",
-       "IVAP            0.029828\n",
-       "CVAP            0.029908\n",
+       "Uncalibrated    0.045700\n",
+       "Platt           0.050871\n",
+       "Isotonic        0.045829\n",
+       "Platt-CV        0.043268\n",
+       "Isotonic-CV     0.037654\n",
+       "IVAP            0.029632\n",
+       "CVAP            0.030014\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1173,24 +1173,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 36,
    "id": "7db3752b-7352-4b94-8510-d1be7dfe1cf8",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Uncalibrated    1.100995\n",
-       "Platt           0.632076\n",
-       "Isotonic        0.620669\n",
-       "Platt-CV        0.535566\n",
-       "Isotonic-CV     0.461955\n",
-       "IVAP            0.344549\n",
-       "CVAP            0.358485\n",
+       "Uncalibrated    1.098787\n",
+       "Platt           0.637776\n",
+       "Isotonic        0.619005\n",
+       "Platt-CV        0.535484\n",
+       "Isotonic-CV     0.459335\n",
+       "IVAP            0.341061\n",
+       "CVAP            0.359266\n",
        "dtype: float64"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1210,9 +1210,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venn_abers_github",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "venn_abers_github"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1224,7 +1224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix accuracy computation in example notebook. Convert inputs to numpy array for va/va_cv.predict. Previous code predicts the same class for all examples.